### PR TITLE
manylinux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         MKN_GCC_PREFERRED: 1
         KUL_GIT_CO: --depth 1
       run: |
-        KLOG=3 ./mkn build -dtKa "-std=c++17 -fPIC" -O 2 -g 0 -W 9 -o mkn_nix
+        KLOG=3 ./mkn build -dtKa "-std=c++17 -fPIC" -O 2 -g 0 -W 9 -o mkn_manylinux
 
     - uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- Chore: The name of the output binary in the build process has been updated. Previously known as "mkn_nix", it will now be referred to as "mkn_manylinux". This change does not affect the functionality of the software, but it may be important for users who interact with the build process or rely on specific naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->