### PR TITLE
parse profile env lines

### DIFF
--- a/README.noformat
+++ b/README.noformat
@@ -30,6 +30,11 @@ Languages supported            Compilers supported
     - C# (partially)
 
 
+1.4 Distributions
+
+Binaries available @ https://github.com/mkn/mkn/releases/tag/latest
+
+
 2.1 Basic project mkn.yaml files
 
 2.1.1 Binary
@@ -141,6 +146,7 @@ profiles:
 
   - name: test
     self: ${OS} ${aaa}              # dependencies on current project profiles, cycles detected
+    sub: project                    # subprojects, follows with rules for resolution, requires URL
     main: test.cpp
     out: ${aaa}                     # override default binary/library name
     install: ${aaa}                 # install binary or library to directory specified
@@ -165,7 +171,7 @@ If no mode tag is found, the -K and -S args will be used if found.
 Linking cannot be guaranteed if no mode is used, but shared is generally default.
 Unless a project requires a mode, it's advised to avoid using one. So it can be overridden with -K or -S.
 
-If a application includes both static and shared dependencies, using the mode "none" is advised.
+If an application includes both static and shared dependencies, using the mode "none" is advised.
 
 
 2.2.1.3 Entry points
@@ -247,8 +253,6 @@ Testing:
     shared : ./mkn clean build -dtSa -EHsc
 
 Example Windows settings can be found at: https://github.com/mkn/maiken/wiki
-
-Binary available @ https://github.com/mkn/maiken/tree/binaries
 
 
 3.2 Unix
@@ -403,7 +407,7 @@ If neither are set the following rules apply
     Unix    : gdb ./bin/<profile>/<binary> <args>
 
  Launch app with gdb, autorun and print backtrace
-   MKN_DBG='gdb -batch -ex "run" -ex "bt" --args' mkn dbg -r "arg0 arg1"
+   MKN_DBG='gdb -batch -ex run -ex bt --args' mkn dbg -r "arg0 arg1"
 
 4.7 Initialising scripts
 
@@ -600,14 +604,18 @@ Description     See section 4
 Key             MKN_COMPILE_THREADS
 Type            uint
 Default         none
-Description     Global override, if set forces all compile calls to use value
-                Example, low RAM systems
+Description     Global override, if set forces all compile calls to use value. Example, low RAM systems
+
+Key             MKN_DEFAULT_BRANCH
+Type            String
+Default         "master"
+Description     Default branch for SCM if not given or set
+
 
 Key             MKN_DBG
 Type            String
 Default         ""
-Description     Sets the preceding command line string when using "dbg"
-                See seciont 4.6
+Description     Sets the preceding command line string when using "dbg". See seciont 4.6
 
 Key             MKN_OBJ
 Type            String

--- a/README.noformat
+++ b/README.noformat
@@ -146,7 +146,7 @@ profiles:
 
   - name: test
     self: ${OS} ${aaa}              # dependencies on current project profiles, cycles detected
-    sub: project                    # subprojects, follows with rules for resolution, requires URL
+    sub: project                    # subprojects, follows "with" rules (4.9) for resolution, requires URL
     main: test.cpp
     out: ${aaa}                     # override default binary/library name
     install: ${aaa}                 # install binary or library to directory specified

--- a/inc/maiken/app.hpp
+++ b/inc/maiken/app.hpp
@@ -309,6 +309,7 @@ class KUL_PUBLISH Application : public Constants {
   std::vector<std::pair<maiken::Source, bool>> srcs;
   std::vector<std::pair<std::string, bool>> incs;
   mkn::kul::SCM const* scm = 0;
+  std::vector<ProjectInfo> subs;
 };
 
 class Applications : public Constants {

--- a/inc/maiken/defs.hpp
+++ b/inc/maiken/defs.hpp
@@ -31,6 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef _MAIKEN_DEFS_HPP_
 #define _MAIKEN_DEFS_HPP_
 
+#include "mkn/kul/env.hpp"
 #include "mkn/kul/defs.hpp"
 
 #ifndef MKN_LANG
@@ -78,6 +79,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif /* _KUL_PROC_LOOP_NSLEEP_ */
 
 namespace maiken {
+
+auto inline defaultSCMBranchName() { return mkn::kul::env::GET("MKN_DEFAULT_BRANCH", "master"); }
+
 class Constants {
  public:
   static constexpr auto STR_MAIKEN = "maiken";
@@ -124,6 +128,7 @@ class Constants {
   static constexpr auto STR_REMOTE = "remote";
   static constexpr auto STR_SCM = "scm";
   static constexpr auto STR_SELF = "self";
+  static constexpr auto STR_SUB = "sub";
   static constexpr auto STR_PROFILE = "profile";
   static constexpr auto STR_PROFILES = "profiles";
 

--- a/inc/maiken/project.hpp
+++ b/inc/maiken/project.hpp
@@ -31,13 +31,19 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef _MAIKEN_PROJECT_HPP_
 #define _MAIKEN_PROJECT_HPP_
 
-#include "mkn/kul/log.hpp"
 #include "mkn/kul/os.hpp"
+#include "mkn/kul/log.hpp"
 #include "mkn/kul/yaml.hpp"
 
 #include "maiken/defs.hpp"
 
 namespace maiken {
+
+struct ProjectInfo {
+  std::string local /*&*/, profiles, name, version /*#*/, scm;
+
+  ProjectInfo static PARSE_LINE(std::string const& line);
+};
 
 class Application;
 
@@ -53,13 +59,13 @@ class KUL_PUBLISH Project : public mkn::kul::yaml::File, public Constants {
   Project(mkn::kul::File const& f) : mkn::kul::yaml::File(f), m_dir(f.dir().real()) {}
   Project(Project const& p) : mkn::kul::yaml::File(p), m_dir(p.m_dir.real()) {}
   mkn::kul::Dir const& dir() const { return m_dir; }
-  const mkn::kul::yaml::Validator validator() const;
+  mkn::kul::yaml::Validator validator() const;
 
   static mkn::kul::hash::map::S2S populate_tests(YAML::Node const& node);
   std::vector<Application const*> getBinaryTargets() const;
 
  private:
-  const mkn::kul::Dir m_dir;
+  mkn::kul::Dir const m_dir;
   friend class Projects;
   friend class Application;
   friend class mkn::kul::yaml::File;

--- a/inc/maiken/scm.hpp
+++ b/inc/maiken/scm.hpp
@@ -43,8 +43,9 @@ class SCMGetter {
     return s;
   }
   static bool HAS(mkn::kul::Dir const& d);
-  static std::string REPO(mkn::kul::Dir const& d, std::string const& r, bool module);
-  static mkn::kul::SCM const* GET(mkn::kul::Dir const& d, std::string const& r, bool module);
+  static std::string REPO(mkn::kul::Dir const& d, std::string const& r, bool module = false);
+  static mkn::kul::SCM const* GET(mkn::kul::Dir const& d, std::string const& r,
+                                  bool module = false);
 
  private:
   static bool IS_SOLID(std::string const& r);

--- a/inc/maiken/settings.hpp
+++ b/inc/maiken/settings.hpp
@@ -60,7 +60,7 @@ class Settings : public mkn::kul::yaml::File, public Constants {
 
   Settings const* super() const { return sup.get(); }
 
-  const mkn::kul::yaml::Validator validator() const;
+  mkn::kul::yaml::Validator validator() const;
   std::vector<std::string> const& remoteModules() const { return rms; }
   std::vector<std::string> const& remoteRepos() const { return rrs; }
   mkn::kul::hash::map::S2S const& properties() const { return ps; }

--- a/mkn.yaml
+++ b/mkn.yaml
@@ -4,7 +4,7 @@ name: mkn
 # scm: https://github.com/mkn/mkn
 version: master
 property:
-  DATE: 19-NOV-2023
+  DATE: 28-FEB-2024
 
 parent: bin
 mode: none

--- a/mkn.yaml
+++ b/mkn.yaml
@@ -65,7 +65,7 @@ profile:
 - name: server
   parent: lib
   with: io.cereal mkn.ram[https]
-  main: src/server.cpp
+  main: server.cpp
   mode: none
 
 - name: format

--- a/src/maiken.cpp
+++ b/src/maiken.cpp
@@ -94,9 +94,10 @@ mkn::kul::hash::set::String maiken::Application::inactiveMains() const {
 
 void maiken::Application::populateMaps(YAML::Node const& n) KTHROW(mkn::kul::Exception) {
   if (n[STR_ENV]) {
-    if (n[STR_ENV].IsScalar())
-      evs.emplace_back(PARSE_ENV_NODE(n[STR_ENV], *this));
-    else
+    if (n[STR_ENV].IsScalar()) {
+      for (auto const& line : mkn::kul::String::LINES(n[STR_ENV].Scalar()))
+        evs.emplace_back(PARSE_ENV_NODE(decltype(n[STR_ENV]){line}, *this));
+    } else
       for (auto const& c : n[STR_ENV]) evs.emplace_back(PARSE_ENV_NODE(c, *this));
   }
 

--- a/src/maiken/build/bin.cpp
+++ b/src/maiken/build/bin.cpp
@@ -95,10 +95,6 @@ class Executioner : public Constants {
     if (dryRun)
       KOUT(NON) << cpc.cmd();
     else {
-      app.checkErrors(cpc);
-      KOUT(INF) << cpc.cmd();
-      KOUT(NON) << "Creating bin: " << mkn::kul::File(cpc.file()).real();
-
       if (AppVars::INSTANCE().dump()) {
         std::string base = mkn::kul::File(cpc.file()).name();
         mkn::kul::io::Writer(mkn::kul::File(base + ".txt", cmdLogDir)) << cpc.cmd();
@@ -140,6 +136,10 @@ void maiken::Application::buildExecutable(mkn::kul::hash::set::String const& obj
 
   auto cpc = Executioner::build_exe(objects, starDirs, file, name, install, *this);
   Executioner::print(cpc, *this);
+
+  checkErrors(cpc);
+  KOUT(INF) << cpc.cmd();
+  KOUT(NON) << "Creating bin: " << mkn::kul::File(cpc.file()).real();
 }
 
 void maiken::Application::buildTest(mkn::kul::hash::set::String const& objects)
@@ -207,6 +207,7 @@ maiken::CompilerProcessCapture maiken::Application::buildLibrary(
     if (dryRun)
       KOUT(NON) << cpc.cmd();
     else {
+      Executioner::print(cpc, *this);
       checkErrors(cpc);
       KOUT(INF) << cpc.cmd();
       KOUT(NON) << "Creating lib: " << mkn::kul::File(cpc.file()).real();

--- a/src/maiken/compiler/gcc.cpp
+++ b/src/maiken/compiler/gcc.cpp
@@ -31,6 +31,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "maiken.hpp"
 #include <unordered_set>
 
+#include <cstdint>
+
 maiken::cpp::GccCompiler::GccCompiler(int const& v) : CCompiler(v) {
   m_optimise_c.insert({{0, ""},
                        {1, "-O1"},
@@ -196,9 +198,9 @@ maiken::CompilerProcessCapture maiken::cpp::GccCompiler::buildLibrary(LinkDAO& d
   for (std::string const& o : objects) p << mkn::kul::File(o).escm();
 
   {
-    auto ll(mkn::kul::env::GET("MKN_LIB_LINK_LIB"));
+    auto ll(mkn::kul::env::GET("MKN_LIB_LINK_LIB", "0"));
     if (ll.size() && mode == compiler::Mode::SHAR) {
-      uint16_t llv = mkn::kul::String::UINT16(ll);
+      std::uint16_t llv = mkn::kul::String::UINT16(ll);
       for (std::string const& path : libPaths) p.arg("-L" + path);
       if (llv == 1) {
         for (std::string const& lib : libs) p.arg("-l" + lib);

--- a/src/maiken/defs.cpp
+++ b/src/maiken/defs.cpp
@@ -58,6 +58,7 @@ constexpr char const* maiken::Constants::STR_FILE;
 constexpr char const* maiken::Constants::STR_ARG;
 constexpr char const* maiken::Constants::STR_INSTALL;
 constexpr char const* maiken::Constants::STR_SELF;
+constexpr char const* maiken::Constants::STR_SUB;
 
 constexpr char const* maiken::Constants::STR_VALUE;
 constexpr char const* maiken::Constants::STR_MAIN;

--- a/src/maiken/depmod.cpp
+++ b/src/maiken/depmod.cpp
@@ -102,7 +102,7 @@ mkn::kul::Dir maiken::Application::resolveDepOrModDirectory(YAML::Node const& n,
         if (Github::GET_LATEST(depName, version)) return version;
 #endif  //_MKN_WITH_MKN_RAM_
 
-        return "master";
+        return defaultSCMBranchName();
       };
       std::string version(resolveSCMBranch());
       if (version.empty()) {

--- a/src/maiken/process.cpp
+++ b/src/maiken/process.cpp
@@ -31,6 +31,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "maiken.hpp"
 
 void maiken::Application::process() KTHROW(mkn::kul::Exception) {
+  mkn::kul::hash::map::S2S oldEvs;
+  for (auto const& ev : evs) {
+    std::string const& v = mkn::kul::env::GET(ev.name());
+    if (v.size()) oldEvs.insert(ev.name(), v);
+    mkn::kul::env::SET(ev.name(), ev.value());
+  }
+
   auto const& cmds = CommandStateMachine::INSTANCE().commands();
 
   mkn::kul::os::PushDir pushd(this->project().dir());
@@ -134,4 +141,6 @@ void maiken::Application::process() KTHROW(mkn::kul::Exception) {
     run(cmds.count(STR_DBG));
   CommandStateMachine::INSTANCE().reset();
   AppVars::INSTANCE().show(0);
+
+  for (auto const& oldEv : oldEvs) mkn::kul::env::SET(oldEv.first.c_str(), oldEv.second.c_str());
 }

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -32,6 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "maiken/defs.hpp"
 #include "maiken/string.hpp"
+#include "maiken/github.hpp"
 #include "maiken/project.hpp"
 
 maiken::ProjectInfo maiken::ProjectInfo::PARSE_LINE(std::string const& line) {
@@ -55,6 +56,10 @@ maiken::ProjectInfo maiken::ProjectInfo::PARSE_LINE(std::string const& line) {
   };
   if_set(am, local);
   if_set(ha, version);
+
+#if defined(_MKN_WITH_MKN_RAM_)
+  if (version.size() == 0 && scm.size() && !Github::GET_LATEST(scm, version)) version = "";
+#endif
 
   return {local, profiles, proj, version, scm};
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -142,7 +142,7 @@ bool maiken::Settings::SET(std::string const& s) {
   return 0;
 }
 
-const mkn::kul::yaml::Validator maiken::Settings::validator() const {
+mkn::kul::yaml::Validator maiken::Settings::validator() const {
   using namespace mkn::kul::yaml;
 
   std::vector<NodeValidator> masks;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a section for distributions with a link to binaries on GitHub.
	- Added a `sub` field under the `test` profile in project configurations.
	- Updated advice on using the mode "none" for applications with both static and shared dependencies.

- **Bug Fixes**
	- Removed a broken link to binaries in the Windows settings section.
	- Corrected a typo in the `MKN_DBG` environment variable setting for gdb.

- **Documentation**
	- Added new configuration keys `MKN_DEFAULT_BRANCH` and updated descriptions for existing keys like `MKN_COMPILE_THREADS` and `MKN_DBG`.

- **Refactor**
	- Restructured logic within the `bin.cpp` file related to building executables and libraries.
	- Refactored the `mod` method in `mods.cpp` for improved parsing of project information.

- **Style**
	- Added `#include <cstdint>` in the `gcc.cpp` file for consistency.
	- Changed `uint16_t` to `std::uint16_t` for `llv` variable declaration in `gcc.cpp`.

- **Chores**
	- Introduced default values for the `module` parameter in the `REPO` and `GET` functions of the `SCMGetter` class in `scm.hpp`.
	- Updated the `validator` method's return type in the `Settings` class in `settings.hpp` and `settings.cpp`.
	- Modified the `validator` method in `project.cpp` to include additional validation nodes like "sub" for project validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->